### PR TITLE
Decrypt privateKey fields as well as passwd fields

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -68,7 +68,7 @@ def main():
   secret = secret[:16]
 
   credentials = open(sys.argv[3]).read()
-  passwords = re.findall(r'<password>\{?(.*?)\}?</password>', credentials)
+  passwords = re.findall(r'<p(?:assword|rivateKey)>\{?(.*?)\}?</p(?:assword|rivateKey)>', credentials)
 
   # You can find the password format at https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/Secret.java#L167-L216
 


### PR DESCRIPTION
Ssh private keys are encrypted in the same manner as passwords in the credentials.xml file.  This decrypts those as well.